### PR TITLE
Added ability for plugins to define configuration appendices

### DIFF
--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/AirportAgentSim.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/AirportAgentSim.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.MarkerManager;
 
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.AirportAgentSimulation;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.config.ConfigurationTypeRegistry;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.plugin.AirportAgentSimulationAPI;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.plugin.LoadedPlugin;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.plugin.PluginActivateException;
@@ -29,6 +30,7 @@ public final class AirportAgentSim {
 	
 	private final Logger logger;
 	private final PluginManager pluginManager;
+	private final ConfigurationTypeRegistry configurationTypeRegistry;
 	private final AirportAgentSimulationAPI aasAPI;
 	
 	public AirportAgentSim(String log4jPrefix, Path pluginsDirectory) {
@@ -41,6 +43,7 @@ public final class AirportAgentSim {
 		
 		this.logger = LogManager.getLogger(this.log4jPrefix + "/default");
 		this.pluginManager = new PluginManager(this.logger, LogManager.getLogger(this.log4jPrefix + "/plugin/default"), MarkerManager.getMarker(this.log4jPrefix + "/plugin"), (s) -> MarkerManager.getMarker(this.log4jPrefix + "/plugin/" + s));
+		this.configurationTypeRegistry = new ConfigurationTypeRegistry();
 		this.aasAPI = new AirportAgentSimulationAPI(this);
 		
 	}
@@ -124,6 +127,10 @@ public final class AirportAgentSim {
 	
 	public PluginManager getPluginManager() {
 		return this.pluginManager;
+	}
+	
+	public ConfigurationTypeRegistry getConfigurationTypeRegistry() {
+		return this.configurationTypeRegistry;
 	}
 	
 }

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/AirportAgentSimulation.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/AirportAgentSimulation.java
@@ -3,6 +3,8 @@ package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurableAttribute;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurationFormatException;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.logging.PluginLogger;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.plugin.Plugin;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.entity.Entity;
@@ -71,8 +73,123 @@ public final class AirportAgentSimulation {
 		return API.getLog4jMarker(plugin);
 	}
 	
-	public static void registerEntity(Class<? extends Entity> e) {
-		// TODO implement
+	/**
+	 * Registers a new configuration type.<br><br>
+	 * 
+	 * Any configuration type must satisfy all of the following requirements:
+	 * <ul>
+	 *   <li>The {@code type} must be {@code public}.</li>
+	 *   <li>The {@code type} must be instantiable, i.e. not an interface or an
+	 *   abstract class.</li>
+	 *   <li>The {@code type} must define a {@code public} zero-argument
+	 *   constructor</li>
+	 *   <li>The {@code type} must be accessible.</li>
+	 *   <li>The same {@code type} cannot be registered multiple times, even if
+	 *   the parameters differ. It is, however, permitted to register the exact
+	 *   same type multiple times to reduce issues originating from different
+	 *   plugins using the same types.</li>
+	 *   <li>Registration of primitive types is forbidden.</li>
+	 * </ul>
+	 * 
+	 * Registering a configuration type will implicitly register all array types
+	 * derived from that type.<br><br>
+	 * 
+	 * @throws ConfigurationFormatException if the configuration type definition
+	 * is illegal for any reason
+	 * 
+	 * @param type the type to register
+	 */
+	public static void registerConfigurationType(Class<?> type) throws ConfigurationFormatException {
+		API.registerConfigurationType(type);
+	}
+	
+	/**
+	 * Registers a new configuration type.<br><br>
+	 * 
+	 * Any configuration type must satisfy all of the following requirements:
+	 * <ul>
+	 *   <li>The {@code type} must be {@code public}.</li>
+	 *   <li>The {@code type} must be instantiable, i.e. not an interface or an
+	 *   abstract class.</li>
+	 *   <li>The {@code type} must define a {@code public} constructor which
+	 *   takes exactly {@code parameters.length} arguments which are of the
+	 *   {@link ConfigurableAttribute#getType() types} defined by
+	 *   {@code parameters}. Note that is insufficient to declare a constructor
+	 *   to whose parameters the types defined by {@code parameters} are
+	 *   assignable; the runtime types must match. It is, however, permitted to
+	 *   register the exact same type multiple times to reduce issues
+	 *   originating from different plugins using the same types.</li>
+	 *   <li>The {@code type} must be accessible.</li>
+	 *   <li>The same {@code type} cannot be registered multiple times, even if
+	 *   the {@code parameters} differ.</li>
+	 *   <li>Registration of primitive types is forbidden. This implies that
+	 *   parameters of primitive types cannot be used. If using primitive types
+	 *   is desired, an additional constructor must be defined for the purpose
+	 *   of registering a class as a configuration type.</li>
+	 * </ul>
+	 * 
+	 * Registering a configuration type will implicitly register all array types
+	 * derived from that type.<br><br>
+	 * 
+	 * If the configuration type uses complex parameters, those complex types
+	 * must also be registered as configuration types. However, the order of
+	 * registration is irrelevant, i.e. it is explicitly not required that the
+	 * type of a complex parameter is already registered when registering a
+	 * dependent type. Therefore, self-dependencies and circular dependencies
+	 * between types are permitted.<br><br>
+	 * 
+	 * @throws ConfigurationFormatException if the configuration type definition
+	 * is illegal for any reason
+	 * 
+	 * @param type the type to register
+	 * @param parameters the parameters used by the type
+	 */
+	public static void registerConfigurationType(Class<?> type, ConfigurableAttribute[] parameters) throws ConfigurationFormatException {
+		API.registerConfigurationType(type, parameters);
+	}
+	
+	/**
+	 * Registers a new plugin {@link Entity}. This will register the entity type
+	 * as a configuration type.<br><br>
+	 * 
+	 * The type will be identified using the given {@code entityTypeID}. The
+	 * {@code entityTypeID} must be unique between all plugins.<br><br>
+	 * 
+	 * The {@code type} will be registered as a configuration type as if by
+	 * invoking {@link AirportAgentSimulation#registerConfigurationType(Class)}.
+	 * The restrictions for registration of configuration types apply.<br><br>
+	 * 
+	 * @throws ConfigurationFormatException if the configuration type definition
+	 * is illegal for any reason
+	 * 
+	 * @param entityTypeID the unique entity type ID for the given type
+	 * @param type the type to register
+	 */
+	public static void registerEntity(String entityTypeID, Class<? extends Entity> type) throws ConfigurationFormatException {
+		API.registerEntity(entityTypeID, type);
+	}
+	
+	/**
+	 * Registers a new plugin {@link Entity}. This will register the entity type
+	 * as a configuration type.<br><br>
+	 * 
+	 * The type will be identified using the given {@code entityTypeID}. The
+	 * {@code entityTypeID} must be unique between all plugins.<br><br>
+	 * 
+	 * The {@code type} will be registered as a configuration type as if by
+	 * invoking
+	 * {@link AirportAgentSimulation#registerConfigurationType(Class, ConfigurableAttribute[])}.
+	 * The restrictions for registration of configuration types apply.<br><br>
+	 * 
+	 * @throws ConfigurationFormatException if the configuration type definition
+	 * is illegal for any reason
+	 * 
+	 * @param entityTypeID the unique entity type ID for the given type
+	 * @param type the type to register
+	 * @param parameters the parameters used by the type
+	 */
+	public static void registerEntity(String entityTypeID, Class<? extends Entity> type, ConfigurableAttribute[] parameters) throws ConfigurationFormatException {
+		API.registerEntity(entityTypeID, type, parameters);
 	}
 	
 	/**

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/config/ConfigurableAttribute.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/config/ConfigurableAttribute.java
@@ -1,0 +1,116 @@
+package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config;
+
+import org.apache.commons.lang3.Validate;
+
+public final class ConfigurableAttribute {
+	
+	private final String configKey;
+	private final boolean required;
+	private final Class<?> type;
+	private final Object defaultValue;
+	
+	/**
+	 * Constructs a new required configurable attribute. It will use the given
+	 * key and be of the given type.<br><br>
+	 * 
+	 * @param configKey the configuration key
+	 * @param type the value type
+	 */
+	public ConfigurableAttribute(String configKey, Class<?> type) {
+		Validate.notNull(configKey);
+		Validate.notNull(type);
+		this.configKey = configKey;
+		this.required = true;
+		this.type = type;
+		this.defaultValue = null;
+	}
+	
+	/**
+	 * Constructs a new optional configurable attribute. It will use the given
+	 * key and be of the given type. If the value is omitted from the
+	 * configuration, it will assume the given default value.<br><br>
+	 * 
+	 * <b>The given default value must be immutable, i.e. its internal state
+	 * must not change at any point, because the provided instance will be
+	 * shared between all occurrences of this attribute in and between
+	 * configurations.</b>
+	 * 
+	 * @param configKey the configuration key
+	 * @param type the value type
+	 * @param defaultValue the immutable default value
+	 */
+	public <T> ConfigurableAttribute(String configKey, Class<T> type, T defaultValue) {
+		Validate.notNull(configKey);
+		Validate.notNull(type);
+		Validate.notNull(defaultValue);
+		Validate.isTrue(type.isInstance(defaultValue), "default value must be assignable to the parameter type");
+		this.configKey = configKey;
+		this.required = false;
+		this.type = type;
+		this.defaultValue = defaultValue;
+	}
+	
+	/**
+	 * Returns the non-{@code null} key used to identify this attribute in a
+	 * configuration file.<br><br>
+	 * 
+	 * @return the configuration key
+	 */
+	public String getConfigurationKey() {
+		return this.configKey;
+	}
+	
+	/**
+	 * Returns {@code true} if, and only if, this value is required. If a
+	 * required value is omitted in the configuration, parsing will fail.
+	 * <br><br>
+	 * 
+	 * If this method returns {@code false}, {@link #getDefaultValue()} can be
+	 * used to obtain the default value for this attribute.<br><br>
+	 * 
+	 * @return {@code true} if this value is required, {@code false} otherwise
+	 */
+	public boolean isRequired() {
+		return this.required;
+	}
+	
+	/**
+	 * Returns the value type for this attribute. When parsing the
+	 * configuration, the value defined for this attribute's key will be assumed
+	 * to be of this type.<br><br>
+	 * 
+	 * @return the value type
+	 */
+	public Class<?> getType() {
+		return this.type;
+	}
+	
+	/**
+	 * Returns a default value for this attribute. The default attribute is
+	 * immutable.<br><br>
+	 * 
+	 * A default value is present, it will never be {@code null}. A default
+	 * value is present if, and only if, {@link #isRequired()} returns
+	 * {@code false}.<br><br>
+	 * 
+	 * @return the immutable default value
+	 */
+	public Object getDefaultValue() {
+		return this.defaultValue;
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof ConfigurableAttribute
+				&& this.configKey.equals(((ConfigurableAttribute) other).configKey)
+				&& this.required == ((ConfigurableAttribute) other).required
+				&& this.type == ((ConfigurableAttribute) other).type
+				&& (this.defaultValue == null ? ((ConfigurableAttribute) other).defaultValue == null : this.defaultValue.equals(((ConfigurableAttribute) other).defaultValue));
+	}
+	
+	@Override
+	public int hashCode() {
+		return this.type.hashCode();
+	}
+	
+}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/config/ConfigurationFormatException.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/config/ConfigurationFormatException.java
@@ -1,0 +1,24 @@
+package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config;
+
+public class ConfigurationFormatException extends Exception {
+	
+	private static final long serialVersionUID = -3834249880720664429L;
+	
+	
+	public ConfigurationFormatException() {
+		super();
+	}
+	
+	public ConfigurationFormatException(String message) {
+		super(message);
+	}
+	
+	public ConfigurationFormatException(Throwable cause) {
+		super(cause);
+	}
+	
+	public ConfigurationFormatException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
+}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/config/ConfigurationParseException.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/config/ConfigurationParseException.java
@@ -1,0 +1,24 @@
+package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config;
+
+public class ConfigurationParseException extends Exception {
+	
+	private static final long serialVersionUID = -3834249880720664429L;
+	
+	
+	public ConfigurationParseException() {
+		super();
+	}
+	
+	public ConfigurationParseException(String message) {
+		super(message);
+	}
+	
+	public ConfigurationParseException(Throwable cause) {
+		super(cause);
+	}
+	
+	public ConfigurationParseException(String message, Throwable cause) {
+		super(message, cause);
+	}
+	
+}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/geometry/Point.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/geometry/Point.java
@@ -1,11 +1,20 @@
 package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.geometry;
 
+import org.apache.commons.lang3.Validate;
+
 public final class Point {
 	
 	private final int x;
 	private final int y;
 	
 	public Point(int x, int y) {
+		this.x = x;
+		this.y = y;
+	}
+	
+	public Point(Integer x, Integer y) {
+		Validate.notNull(x);
+		Validate.notNull(y);
 		this.x = x;
 		this.y = y;
 	}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/Agent.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/Agent.java
@@ -1,12 +1,7 @@
 package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.entity;
 
-import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.geometry.Point;
-import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.World;
-
 public abstract class Agent extends MovingEntity {
 	
-	public Agent(World world, Point pos, int width, int height) {
-		super(world, pos, width, height);
-	}
+	public Agent() {}
 	
 }

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/Entity.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/Entity.java
@@ -7,39 +7,35 @@ import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulati
 
 public abstract sealed class Entity permits MovingEntity, StaticEntity {
 	
-	private final World world;
+	private World world;
 	private int posX;
 	private int posY;
 	private int width;
 	private int height;
 	
-	Entity(World world, int posX, int posY, int width, int height) {
-		Validate.isTrue(posX + width < world.getWidth(), "Entity out of bounds");
-		Validate.isTrue(posY + height < world.getHeight(), "Entity out of bounds");
-		this.world = world;
-		this.posX = posX;
-		this.posY = posY;
-		this.width = width;
-		this.height = height;
+	Entity() {}
+	
+	public final boolean isSpawned() {
+		return this.world != null;
 	}
 	
-	public World getWorld() {
+	public final World getWorld() {
 		return this.world;
 	}
 	
-	public Point getPosition() {
+	public final Point getPosition() {
 		return new Point(this.posX, this.posY);
 	}
 	
-	public int getWidth() {
+	public final int getWidth() {
 		return this.width;
 	}
 	
-	public int getHeight() {
+	public final int getHeight() {
 		return this.height;
 	}
 	
-	public void setPosition(Point pos) {
+	public final void setPosition(Point pos) {
 		Validate.notNull(pos, "Position cannot be null");
 		Validate.isTrue(pos.getX() + this.width < this.world.getWidth(), "Entity out of bounds");
 		Validate.isTrue(pos.getY() + this.height < this.world.getHeight(), "Entity out of bounds");
@@ -47,17 +43,34 @@ public abstract sealed class Entity permits MovingEntity, StaticEntity {
 		this.posY = pos.getY();
 	}
 	
-	public void setWidth(int width) {
+	public final void setWidth(int width) {
 		Validate.isTrue(this.posX + width < this.world.getWidth(), "Entity out of bounds");
 		this.width = width;
 	}
 	
-	public void setHeight(int height) {
+	public final void setHeight(int height) {
 		Validate.isTrue(this.posY + height < this.world.getHeight(), "Entity out of bounds");
 		this.height = height;
 	}
 	
-	public void kill() {
+	public final void spawn(World world, int posX, int posY, int width, int height) {
+		
+		Validate.notNull(world, "World must not be null");
+		Validate.isTrue(posX + width < world.getWidth(), "Entity out of bounds");
+		Validate.isTrue(posY + height < world.getHeight(), "Entity out of bounds");
+		
+		if(isSpawned())
+			throw new IllegalStateException("Cannot spawn an entity which has already been spawned");
+		
+		this.world = world;
+		this.posX = posX;
+		this.posY = posY;
+		this.width = width;
+		this.height = height;
+		
+	}
+	
+	public final void kill() {
 		// TODO implement
 	}
 	

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/MovingEntity.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/MovingEntity.java
@@ -3,31 +3,28 @@ package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulat
 import org.apache.commons.lang3.Validate;
 
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.geometry.Point;
-import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.World;
 
 public abstract non-sealed class MovingEntity extends Entity {
-
+	
 	private double direction;
 	private double speed;
 	
-	public MovingEntity(World world, Point pos, int width, int height) {
-		super(world, pos.getX(), pos.getY(), width, height);
-	}
+	public MovingEntity() {}
 	
-	public double getDirection() {
+	public final double getDirection() {
 		return this.direction;
 	}
 	
-	public double getSpeed() {
+	public final double getSpeed() {
 		return this.speed;
 	}
 	
-	public void setSpeed(double speed) {
+	public final void setSpeed(double speed) {
 		Validate.isTrue(speed >= 0.0D, "Speed cannot be negative");
 		this.speed = speed;
 	}
 	
-	public void turn(Point p) {
+	public final void turn(Point p) {
 		Validate.notNull(p);
 		// TODO implement
 	}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/StaticEntity.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/api/simulation/entity/StaticEntity.java
@@ -1,12 +1,7 @@
 package dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.entity;
 
-import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.geometry.Point;
-import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.World;
-
 public abstract non-sealed class StaticEntity extends Entity {
 	
-	public StaticEntity(World world, Point pos, int width, int height) {
-		super(world, pos.getX(), pos.getY(), width, height);
-	}
+	public StaticEntity() {}
 	
 }

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/ConfigurationTypeRegistry.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/ConfigurationTypeRegistry.java
@@ -1,0 +1,239 @@
+package dhbw.sose2022.softwareengineering.airportagentsim.simulation.config;
+
+import java.lang.reflect.Array;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import org.apache.commons.lang3.Validate;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurableAttribute;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurationFormatException;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurationParseException;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.entity.Entity;
+
+public final class ConfigurationTypeRegistry {
+	
+	private final HashMap<Class<?>, RegistryEntry> entries = new HashMap<Class<?>, RegistryEntry>();
+	
+	private final HashMap<String, Class<? extends Entity>> entitiesByID = new HashMap<String, Class<? extends Entity>>();
+	
+	
+	public ConfigurationTypeRegistry() {
+		registerSimpleEntry(Boolean.class);
+		registerSimpleEntry(Byte.class);
+		registerSimpleEntry(Short.class);
+		registerSimpleEntry(Integer.class);
+		registerSimpleEntry(Long.class);
+		registerSimpleEntry(Float.class);
+		registerSimpleEntry(Double.class);
+	}
+	
+	@SuppressWarnings("unchecked")
+	public <T> T parseJSONObject(Class<T> type, JSONObject object) throws ConfigurationFormatException, ConfigurationParseException {
+		
+		if(type.isArray())
+			throw new ConfigurationParseException("Cannot parse JSON object to array");
+		
+		RegistryEntry registryEntry = this.entries.get(type);
+		if(registryEntry == null || !(registryEntry instanceof ObjectRegistryEntry))
+			throw new ConfigurationFormatException("No configuration format defined for " + type.getSimpleName());
+		
+		Object o = parseObject((ObjectRegistryEntry) registryEntry, object);
+		if(!type.isInstance(o))
+			throw new ConfigurationFormatException("Invalid configuration format for " + type.getSimpleName());
+		return (T) o;
+		
+	}
+	
+	@SuppressWarnings("unchecked")
+	public <T> T parseJSONArray(Class<T> type, JSONArray array) throws ConfigurationFormatException, ConfigurationParseException {
+		
+		if(!type.isArray())
+			throw new ConfigurationParseException("Cannot parse JSON array to non-array object");
+		
+		Object o = parseArray(type, array);
+		if(!type.isInstance(o))
+			throw new ConfigurationFormatException("Invalid configuration format for " + type.getSimpleName());
+		return (T) o;
+		
+	}
+	
+	public void registerConfigurationType(Class<?> type, ConfigurableAttribute[] parameters) throws ConfigurationFormatException {
+		
+		Validate.notNull(type);
+		Validate.noNullElements(parameters);
+		Validate.isTrue(!type.isArray(), "Cannot define array configuration types explicitly");
+		
+		if(parameters.length > 0) {
+			HashSet<String> configKeys = new HashSet<String>();
+			for(int i = 0; i < parameters.length; i++)
+				if(!configKeys.add(parameters[i].getConfigurationKey()))
+					throw new ConfigurationFormatException("Cannot define a configuration type which defines multiple parameters using the same configuration key");
+		}
+		
+		ObjectRegistryEntry ore = new ObjectRegistryEntry(type, parameters);
+		if(this.entries.containsKey(type)) {
+			if(ore.equals(this.entries.get(type)))
+				return;
+			throw new ConfigurationFormatException("Cannot redefine configuration type " + type.getSimpleName());
+		}
+		this.entries.put(type, ore);
+		
+	}
+	
+	public boolean isEntityIDRegistered(String entityID) {
+		return this.entitiesByID.containsKey(entityID);
+	}
+	
+	public Entity parseEntity(String entityID, JSONObject object) throws ConfigurationFormatException, ConfigurationParseException {
+		Class<? extends Entity> entityType = this.entitiesByID.get(entityID);
+		if(entityType == null)
+			throw new ConfigurationFormatException("Unknown entity ID \"" + entityID + "\"");
+		return parseJSONObject(entityType, object);
+	}
+	
+	public void registerEntityID(String entityID, Class<? extends Entity> type) throws IllegalArgumentException {
+		if(this.entitiesByID.containsKey(entityID))
+			throw new IllegalArgumentException("Duplicate entity id: " + entityID);
+		this.entitiesByID.put(entityID, type);
+	}
+	
+	
+	private void registerSimpleEntry(Class<?> type) {
+		this.entries.put(type, new SimpleRegistryEntry(type));
+	}
+	
+	private Object parseObject(ObjectRegistryEntry registryEntry, JSONObject object) throws ConfigurationFormatException, ConfigurationParseException {
+		
+		Object[] parameters = new Object[registryEntry.parameters.length];
+		
+		HashSet<Integer> undefinedIndecies = new HashSet<Integer>();
+		for(int i = 0; i < parameters.length; i++)
+			undefinedIndecies.add(i);
+		
+		for(Object keyObject : object.keySet()) {
+			
+			String key = String.valueOf(keyObject);
+			Integer parameterIndex = registryEntry.parametersByName.get(key);
+			if(parameterIndex == null)
+				throw new ConfigurationParseException("Attempting to parse an object of type " + registryEntry.target.getSimpleName() + ", but found illegal configuration key \"" + key + "\"");
+			
+			ConfigurableAttribute childAttribute = registryEntry.parameters[parameterIndex];
+			try {
+				parameters[parameterIndex] = parseJSONElement(childAttribute.getType(), object.get(keyObject));
+			} catch(ConfigurationParseException e) {
+				throw new ConfigurationParseException("Failed to parse an object of type " + registryEntry.target.getSimpleName() + ": " + e.getMessage());
+			}
+			
+			undefinedIndecies.remove(parameterIndex);
+			
+		}
+		
+		for(Integer undefinedIndex : undefinedIndecies) {
+			if(registryEntry.parameters[undefinedIndex].isRequired())
+				throw new ConfigurationParseException("Attempting to parse an object of type " + registryEntry.target.getSimpleName() + ", but required configuration key \"" + registryEntry.parameters[undefinedIndex].getConfigurationKey() + "\" is missing");
+			parameters[undefinedIndex] = registryEntry.parameters[undefinedIndex].getDefaultValue();
+		}
+		
+		return registryEntry.parse(parameters);
+		
+	}
+	
+	private Object parseArray(Class<?> targetType, JSONArray array) throws ConfigurationFormatException, ConfigurationParseException {
+		
+		Class<?> componentType = targetType.getComponentType();
+		
+		int length = array.size();
+		Object resultArray = Array.newInstance(componentType, length);
+		
+		for(int i = 0; i < length; i++) {
+			try {
+				Array.set(resultArray, i, parseJSONElement(componentType, array.get(i)));
+			} catch(ConfigurationParseException e) {
+				throw new ConfigurationParseException("Failed to parse an array of type " + targetType.getSimpleName() + ": Error at index " + i + ": " + e.getMessage());
+			}
+		}
+		
+		return resultArray;
+		
+	}
+	
+	private Object parseJSONElement(Class<?> targetType, Object element) throws ConfigurationFormatException, ConfigurationParseException {
+		
+		if(targetType.isArray()) {
+			if(!(element instanceof JSONArray))
+				throw new ConfigurationParseException("Failed to parse " + targetType.getSimpleName() + ". Expected " + JSONArray.class.getSimpleName() + ", got " + element.getClass().getSimpleName());
+			return parseArray(targetType, (JSONArray) element);
+		}
+		
+		RegistryEntry registryEntry = this.entries.get(targetType);
+		
+		if(registryEntry instanceof SimpleRegistryEntry) {
+			
+			SimpleRegistryEntry sre = (SimpleRegistryEntry) registryEntry;
+			
+			if(Number.class.isAssignableFrom(sre.target)) {
+				
+				if(!(element instanceof Number))
+					throw new ConfigurationParseException("Expected " + targetType.getSimpleName() + ", got " + element.getClass().getSimpleName());
+				
+				Number converted = parseNumber((Number) element, sre.target);
+				if(converted != null)
+					return converted;
+				
+			}
+			
+			if(!sre.target.isInstance(element))
+				throw new ConfigurationParseException("Expected " + targetType.getSimpleName() + ", got " + element.getClass().getSimpleName());
+			
+			return element;
+			
+		} else if(registryEntry instanceof ObjectRegistryEntry) {
+			
+			if(!(element instanceof JSONObject))
+				throw new ConfigurationParseException("Failed to parse " + targetType.getSimpleName() + ". Expected " + JSONObject.class.getSimpleName() + ", got " + element.getClass().getSimpleName());
+			
+			return parseObject((ObjectRegistryEntry) registryEntry, (JSONObject) element);
+			
+		} else {
+			throw new ConfigurationFormatException("No configuration type definition for type " + targetType.getSimpleName());
+		}
+		
+	}
+	
+	private Number parseNumber(Number original, Class<?> target) throws ConfigurationFormatException, ConfigurationParseException {
+		
+		if(original.getClass() == target)
+			return original;
+		
+		if(target == Double.class)
+			return Double.valueOf(original.doubleValue());
+		if(target == Float.class)
+			return Float.valueOf(original.floatValue());
+		
+		if(!(original instanceof Long) && !(original instanceof Integer) && !(original instanceof Short) && !(original instanceof Byte))
+			throw new ConfigurationParseException("Attempting to parse an object of type " + target.getSimpleName() + ", but configuration value is not an integer");
+		
+		Number converted;
+		if(target == Byte.class) {
+			converted = Byte.valueOf(original.byteValue());
+		} else if(target == Short.class) {
+			converted = Short.valueOf(original.shortValue());
+		} else if(target == Integer.class) {
+			converted = Integer.valueOf(original.intValue());
+		} else if(target == Long.class) {
+			converted = Long.valueOf(original.longValue());
+		} else {
+			return null;
+		}
+		
+		if(converted.longValue() != original.longValue())
+			throw new ConfigurationParseException("Attempting to parse an object of type " + target.getSimpleName() + ", but configuration value is out of range");
+		
+		return converted;
+		
+	}
+	
+}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/ObjectRegistryEntry.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/ObjectRegistryEntry.java
@@ -1,0 +1,80 @@
+package dhbw.sose2022.softwareengineering.airportagentsim.simulation.config;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.stream.Collectors;
+
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurableAttribute;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurationFormatException;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurationParseException;
+
+final class ObjectRegistryEntry extends RegistryEntry {
+	
+	final ConfigurableAttribute[] parameters;
+	
+	private final Constructor<?> c;
+	
+	final HashMap<String, Integer> parametersByName;
+	
+	ObjectRegistryEntry(Class<?> target, ConfigurableAttribute[] parameters) throws ConfigurationFormatException {
+		super(target);
+		
+		this.parameters = parameters;
+		
+		this.c = findConstructor();
+		this.parametersByName = getParameterMap();
+		
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof ObjectRegistryEntry
+				&& this.target.equals(((ObjectRegistryEntry) other).target)
+				&& Arrays.equals(this.parameters, ((ObjectRegistryEntry) other).parameters);
+	}
+	
+	@Override
+	public int hashCode() {
+		return this.target.hashCode() + Arrays.hashCode(this.parameters);
+	}
+	
+	
+	Object parse(Object[] parameters) throws ConfigurationFormatException, ConfigurationParseException {
+		try {
+			return this.c.newInstance(parameters);
+		} catch(InstantiationException e) {
+		} catch(IllegalAccessException e) {
+		} catch(InvocationTargetException e) {
+			throw new ConfigurationParseException("Parsing a configuration object of type " + this.target.getSimpleName() + " failed due to an exception thrown by its constructor.", e);
+		}
+		throw new ConfigurationFormatException("Invalid configuration format for " + this.target.getSimpleName() + ". The class is abstact, not accessible, not public or declares no public constructor using the given parameters.");
+	}
+	
+	
+	private Constructor<?> findConstructor() throws ConfigurationFormatException {
+		if(Modifier.isAbstract(this.target.getModifiers()))
+			throw new ConfigurationFormatException("Invalid configuration format for " + this.target.getSimpleName() + ". The class is abstact.");
+		if(!Modifier.isPublic(this.target.getModifiers()))
+			throw new ConfigurationFormatException("Invalid configuration format for " + this.target.getSimpleName() + ". The class is not public.");
+		Class<?>[] parameters = new Class<?>[this.parameters.length];
+		for(int i = 0; i < parameters.length; i++)
+			parameters[i] = this.parameters[i].getType();
+		try {
+			return this.target.getConstructor(parameters);
+		} catch(NoSuchMethodException e) {
+			throw new ConfigurationFormatException("Invalid configuration format for " + this.target.getSimpleName() + ". The class does not define a public constructor with parameter types " + Arrays.asList(parameters).stream().map((type) -> type.getSimpleName()).collect(Collectors.joining(", ")) + ".");
+		}
+	}
+	
+	private HashMap<String, Integer> getParameterMap() throws ConfigurationFormatException {
+		HashMap<String, Integer> map = new HashMap<String, Integer>();
+		for(int i = 0; i < this.parameters.length; i++)
+			if(map.put(this.parameters[i].getConfigurationKey(), i) != null)
+				throw new ConfigurationFormatException("Invalid configuration format for " + this.target.getSimpleName() + ". Multiple parameters use the same key.");
+		return map;
+	}
+	
+}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/RegistryEntry.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/RegistryEntry.java
@@ -1,0 +1,11 @@
+package dhbw.sose2022.softwareengineering.airportagentsim.simulation.config;
+
+abstract class RegistryEntry {
+	
+	final Class<?> target;
+	
+	RegistryEntry(Class<?> target) {
+		this.target = target;
+	}
+	
+}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/SimpleRegistryEntry.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/config/SimpleRegistryEntry.java
@@ -1,0 +1,20 @@
+package dhbw.sose2022.softwareengineering.airportagentsim.simulation.config;
+
+final class SimpleRegistryEntry extends RegistryEntry {
+	
+	SimpleRegistryEntry(Class<?> target) {
+		super(target);
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		return other instanceof SimpleRegistryEntry
+				&& this.target.equals(((SimpleRegistryEntry) other).target);
+	}
+	
+	@Override
+	public int hashCode() {
+		return this.target.hashCode();
+	}
+	
+}

--- a/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/plugin/AirportAgentSimulationAPI.java
+++ b/src/main/java/dhbw/sose2022/softwareengineering/airportagentsim/simulation/plugin/AirportAgentSimulationAPI.java
@@ -1,10 +1,14 @@
 package dhbw.sose2022.softwareengineering.airportagentsim.simulation.plugin;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.AirportAgentSim;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurableAttribute;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.config.ConfigurationFormatException;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.plugin.Plugin;
+import dhbw.sose2022.softwareengineering.airportagentsim.simulation.api.simulation.entity.Entity;
 import dhbw.sose2022.softwareengineering.airportagentsim.simulation.logging.Log4jPluginLogger;
 
 public final class AirportAgentSimulationAPI {		
@@ -16,15 +20,42 @@ public final class AirportAgentSimulationAPI {
 	}
 	
 	public Log4jPluginLogger getLogger(Plugin plugin) {
+		Validate.notNull(plugin);
 		return getLoadedPlugin0(plugin).getPluginLogger();
 	}
 	
 	public Logger getLog4jLogger(Plugin plugin) {
+		Validate.notNull(plugin);
 		return getLogger(plugin).getLog4jLogger();
 	}
 	
 	public Marker getLog4jMarker(Plugin plugin) {
+		Validate.notNull(plugin);
 		return getLogger(plugin).getLog4jMarker();
+	}
+	
+	public void registerConfigurationType(Class<?> type) throws ConfigurationFormatException {
+		registerConfigurationType(type, new ConfigurableAttribute[0]);
+	}
+	
+	public void registerConfigurationType(Class<?> type, ConfigurableAttribute[] parameters) throws ConfigurationFormatException {
+		Validate.notNull(type);
+		Validate.noNullElements(parameters);
+		this.aas.getConfigurationTypeRegistry().registerConfigurationType(type, parameters);
+	}
+	
+	public void registerEntity(String entityTypeID, Class<? extends Entity> type) throws ConfigurationFormatException {
+		registerEntity(entityTypeID, type, new ConfigurableAttribute[0]);
+	}
+	
+	public void registerEntity(String entityTypeID, Class<? extends Entity> type, ConfigurableAttribute[] parameters) throws ConfigurationFormatException {
+		Validate.notNull(entityTypeID);
+		Validate.notNull(type);
+		Validate.noNullElements(parameters);
+		if(this.aas.getConfigurationTypeRegistry().isEntityIDRegistered(entityTypeID))
+			throw new IllegalArgumentException("Entity ID \"" + entityTypeID + "\" is already in use");
+		this.aas.getConfigurationTypeRegistry().registerConfigurationType(type, parameters);
+		this.aas.getConfigurationTypeRegistry().registerEntityID(entityTypeID, type);
 	}
 	
 	


### PR DESCRIPTION
+ Added additional constructor to Point to account for uses related to the configuration
+ Added exception types ConfigurationFormatException and ConfigurationParseException
+ Added API type ConfigurableAttribute for key and type definitions for parameters used by complex configuration types
+ Added ConfigurationTypeRegistry to allow for dynamic definition of configuration types
+ Added API to register plugin configuration types
+ Added API to register plugin entities
~ Changed Entity to allow spawning, i.e. setting the world, after object construction to prevent plugins from having to deal with simulation-related parent constructor parameters